### PR TITLE
Vertex Buffer Layouts

### DIFF
--- a/Hexagon/src/Hexagon/Renderer/Buffer.h
+++ b/Hexagon/src/Hexagon/Renderer/Buffer.h
@@ -2,6 +2,104 @@
 
 namespace Hexagon {
 
+	enum class ShaderDataType
+	{
+		None = 0, Float, Float2, Float3, Float4, Mat3, Mat4, Int, Int2, Int3, Int4, Bool
+	};
+
+	static uint32_t ShaderDataTypeSize(ShaderDataType type) {
+		switch (type)
+		{
+			case ShaderDataType::Float: 	return sizeof(float);
+			case ShaderDataType::Float2:	return 2*sizeof(float);
+			case ShaderDataType::Float3:	return 3*sizeof(float);
+			case ShaderDataType::Float4:	return 4*sizeof(float);
+			case ShaderDataType::Mat3:		return 3*3*sizeof(float);
+			case ShaderDataType::Mat4:		return 4*4*sizeof(float);
+			case ShaderDataType::Int:		return 4;
+			case ShaderDataType::Int2:		return 4*2;
+			case ShaderDataType::Int3:		return 4*3;
+			case ShaderDataType::Int4:		return 4*4;
+			case ShaderDataType::Bool:		return 1;
+		};
+
+		HX_CORE_ASSERT(false, "Unknown ShaderDataType!");
+		return 0;
+	}
+
+	struct BufferElement 
+	{
+		std::string Name;
+		ShaderDataType Type;
+		uint32_t Size;
+		uint32_t Offset;
+		bool Normalized;
+
+		BufferElement() {}
+
+		BufferElement(ShaderDataType type, const std::string& name, bool normalized = false)
+			: Name(name), Type(type), Size(ShaderDataTypeSize(type)), Offset(0), Normalized(normalized)
+		{
+		}
+
+		uint32_t GetComponentCount() const {
+			switch (Type)
+			{
+				case ShaderDataType::Float:  return 1;
+				case ShaderDataType::Float2: return 2;
+				case ShaderDataType::Float3: return 3;
+				case ShaderDataType::Float4: return 4;
+				case ShaderDataType::Mat3:	 return 3*3;
+				case ShaderDataType::Mat4:	 return 4*4;
+				case ShaderDataType::Int:	 return 1;
+				case ShaderDataType::Int2:	 return 2;
+				case ShaderDataType::Int3:	 return 3;
+				case ShaderDataType::Int4:	 return 4;
+				case ShaderDataType::Bool:	 return 1;
+			};
+
+			HX_CORE_ASSERT(false, "Unknown ShaderDataType:GetElementCount!");
+			return 0;
+		}
+
+	};
+
+	class BufferLayout 
+	{
+	public:
+		BufferLayout() {}
+
+		BufferLayout(const std::initializer_list<BufferElement>& elements)
+			: m_Elements(elements) 
+		{
+			CalculateOffsetAndStride();
+		}
+
+		inline uint32_t GetStride() const { return m_Stride; }
+		inline const std::vector<BufferElement>& GetElements() const { return m_Elements; }
+
+		std::vector<BufferElement>::iterator begin() { return m_Elements.begin(); }
+		std::vector<BufferElement>::iterator end()   { return m_Elements.end(); }
+		std::vector<BufferElement>::const_iterator begin() const { return m_Elements.begin(); }
+		std::vector<BufferElement>::const_iterator end()   const { return m_Elements.end(); }
+
+	private:
+		void CalculateOffsetAndStride() 
+		{
+			uint32_t offset = 0;
+			m_Stride = 0;
+			for (auto& element : m_Elements) 
+			{
+				element.Offset = offset;
+				offset += element.Size;
+				m_Stride += element.Size;
+			}
+		}
+	private:
+		std::vector<BufferElement> m_Elements;
+		uint32_t m_Stride = 0;
+	};
+
 	class VertexBuffer 
 	{
 	public:
@@ -9,6 +107,9 @@ namespace Hexagon {
 
 		virtual void Bind() const = 0;
 		virtual void Unbind() const = 0;
+
+		virtual const BufferLayout& GetLayout() const = 0;
+		virtual void SetLayout(const BufferLayout& layout) = 0;
 
 		static VertexBuffer* Create(float* vertices, uint32_t size);
 	};

--- a/Hexagon/src/Platform/OpenGL/OpenGLBuffer.h
+++ b/Hexagon/src/Platform/OpenGL/OpenGLBuffer.h
@@ -10,10 +10,14 @@ namespace Hexagon {
 		OpenGLVertexBuffer(float* vertices, uint32_t size);
 		virtual ~OpenGLVertexBuffer();
 
-		virtual void Bind() const;
-		virtual void Unbind() const;
+		virtual void Bind() const override;
+		virtual void Unbind() const override;
+
+		virtual const BufferLayout& GetLayout() const override { return m_Layout; }
+		virtual void SetLayout(const BufferLayout& layout) override { m_Layout = layout; }
 	private:
 		uint32_t m_RendererID;
+		BufferLayout m_Layout;
 	};
 
 


### PR DESCRIPTION
Added a BufferLayout class to simplify vertex buffer code implementation.  The user will no longer have to define things such as strides and offsets when describing vertex buffer layouts.  This will also allow for future render API abstraction.